### PR TITLE
improve authentication

### DIFF
--- a/crawler/base.py
+++ b/crawler/base.py
@@ -11,6 +11,7 @@ from django.test.utils import setup_test_environment, teardown_test_environment
 
 from crawler import signals as test_signals
 from crawler.plugins.base import Plugin
+from django.core.management.base import CommandError
 
 #Used for less useful debug output.
 SUPER_DEBUG = 5
@@ -78,8 +79,11 @@ class Crawler(object):
             printable_auth = ', '.join(
                 '%s: %s' % (key, cleanse_setting(key.upper(), value))
                 for key, value in auth.items())
-            LOG.info('Log in with %s' % printable_auth)
-            self.c.login(**auth)
+            LOG.info('try logging in with %s' % printable_auth)
+            if self.c.login(**auth):
+                LOG.info('logged in successfully')
+            else:
+                raise CommandError("logon not possible, check credentials")
 
         self.plugins = []
         for plug in Plugin.__subclasses__():

--- a/crawler/management/commands/crawl.py
+++ b/crawler/management/commands/crawl.py
@@ -34,7 +34,7 @@ class Command(BaseCommand):
         make_option('--no-parent', action='store_true', dest="no_parent", default=False,
             help='Do not crawl URLs which do not start with your base URL'),
         make_option('-a', "--auth", action='store', dest='auth', default=None,
-            help='Authenticate (login:user,password:secret) before crawl')
+            help='Authenticate before crawl. Example: --auth username:foo,password:bar')
     )
 
     help = "Displays all of the url matching routes for the project."


### PR DESCRIPTION
Improved authentication, solving the following problems:
* client is regularly logged out when crawling /logout link (for example in admin), making the rest of the crawl useless
* no check whether login actually succeeds (#4)
* misleading/incorrect help text for option (#3)

The patch logs in the user once, and remembers the user id. Before every new get, it checks whether it is still the same user which is logged in (logging in on every request would consume too much time)